### PR TITLE
Fix the system variable setting error in consecutive setting case

### DIFF
--- a/CANoe/Python_CANoe.py
+++ b/CANoe/Python_CANoe.py
@@ -137,6 +137,7 @@ class CANoe:
             sys_namespace = systemCAN(ns_name)
             sys_value = sys_namespace.Variables(sysvar_name)
             sys_value.Value = var
+            time.sleep(1)       # 等待1秒钟，以防止连续系统变量赋值情况下导致赋值失败的情况
             # print(sys_value)
             # result = sys_value(sys_name)
             #


### PR DESCRIPTION
Add 1 seconds delay in set_SysVar( ) function to fix the system setting error in following case.

[Issue case]
set_SysVar(domain1, sysVar1, 1)
set_SysVar(domain2, sysVar2, 2)
set_SysVar(domain3, sysVar3, 3)
...
In above case, consecutive system variable setting may result in setting error.